### PR TITLE
Allow to use json or zip format without lua version in manifest resources

### DIFF
--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -40,21 +40,21 @@ valid_format = (format) ->
     when "lua", "json", "zip" then true
     else false
 
-expand_splat = (fn) ->
+expand_params = (fn) ->
   =>
     @format = "lua"
 
-    -- splat_rest will contain @params.splat without the matched substring
-    splat_rest = @params.splat\gsub "^(-[%d.]*%d)", (s) ->
+    -- params_rest will contain @params.params without the matched substring
+    params_rest = @params.params\gsub "^(-[%d.]*%d)", (s) ->
       @version = s\sub 2
       ""
     if @version and not valid_lua_version @version
       return status_404
 
-    splat_rest = splat_rest\gsub "(%.%a+)$", (s) ->
+    params_rest = params_rest\gsub "(%.%a+)$", (s) ->
       @format = s\sub 2
       ""
-    if not valid_format(@format) or splat_rest != ""
+    if not valid_format(@format) or params_rest != ""
       return status_404
 
     fn @
@@ -133,13 +133,13 @@ is_stable = (fn) ->
 
 class MoonRocksManifest extends lapis.Application
   [root_manifest: "/manifest"]: cached_manifest is_stable serve_manifest
-  "/manifest*": expand_splat cached_manifest is_stable serve_manifest
+  "/manifest:params": expand_params cached_manifest is_stable serve_manifest
 
   [root_manifest_dev: "/dev/manifest"]: cached_manifest is_dev serve_manifest
-  "/dev/manifest*": expand_splat cached_manifest is_dev serve_manifest
+  "/dev/manifest:params": expand_params cached_manifest is_dev serve_manifest
 
   [user_manifest: "/manifests/:user/manifest"]: serve_manifest
-  "/manifests/:user/manifest*": expand_splat serve_manifest
+  "/manifests/:user/manifest:params": expand_params serve_manifest
 
   "/dev": => redirect_to: @url_for "root_manifest_dev"
   "/manifests/:user": => redirect_to: @url_for("user_manifest", user: @params.user)

--- a/applications/manifest.moon
+++ b/applications/manifest.moon
@@ -1,7 +1,5 @@
 -- app responsible for rendering manifests
 
-MANIFEST_LUA_VERSIONS = { "5.1", "5.2", "5.3" }
-
 lapis = require "lapis"
 
 import redis_cache from require "helpers.redis_cache"
@@ -30,19 +28,36 @@ import cached from require "lapis.cache"
 
 config = require("lapis.config").get!
 
-with_format = (fn) ->
-  =>
-    if format = (@params.version or '')\match "%.(%a+)$"
-      @format = format
-      @params.version = @params.version\sub 1, -format\len! - 2
-    else
-      @format = "lua"
+status_404 = layout: false, status: 404
 
-    switch @format
-      when "lua", "json", "zip"
-        fn @
-      else
-        layout: false, status: 404
+valid_lua_version = (ver) ->
+  switch ver
+    when "5.1", "5.2", "5.3" true
+    else false
+
+valid_format = (format) ->
+  switch format
+    when "lua", "json", "zip" then true
+    else false
+
+expand_splat = (fn) ->
+  =>
+    @format = "lua"
+
+    -- splat_rest will contain @params.splat without the matched substring
+    splat_rest = @params.splat\gsub "^(-[%d.]*%d)", (s) ->
+      @version = s\sub 2
+      ""
+    if @version and not valid_lua_version @version
+      return status_404
+
+    splat_rest = splat_rest\gsub "(%.%a+)$", (s) ->
+      @format = s\sub 2
+      ""
+    if not valid_format(@format) or splat_rest != ""
+      return status_404
+
+    fn @
 
 zipable = (fn) ->
   =>
@@ -63,13 +78,7 @@ zipable = (fn) ->
 
     nil
 
-serve_manifest = capture_errors_404 =>
-  if @params.version
-    assert_valid @params, {
-      { "version", one_of: MANIFEST_LUA_VERSIONS }
-    }
-
-    @version = @params.version
+serve_manifest = zipable capture_errors_404 =>
 
   -- find what we are fetching modules from
   thing = if @params.user
@@ -124,16 +133,13 @@ is_stable = (fn) ->
 
 class MoonRocksManifest extends lapis.Application
   [root_manifest: "/manifest"]: cached_manifest is_stable serve_manifest
+  "/manifest*": expand_splat cached_manifest is_stable serve_manifest
 
   [root_manifest_dev: "/dev/manifest"]: cached_manifest is_dev serve_manifest
-
-  "/manifest-:version": with_format zipable cached_manifest is_stable serve_manifest
-
-  "/dev/manifest-:version": with_format zipable cached_manifest is_dev serve_manifest
+  "/dev/manifest*": expand_splat cached_manifest is_dev serve_manifest
 
   [user_manifest: "/manifests/:user/manifest"]: serve_manifest
-
-  "/manifests/:user/manifest-:version": with_format serve_manifest
+  "/manifests/:user/manifest*": expand_splat serve_manifest
 
   "/dev": => redirect_to: @url_for "root_manifest_dev"
   "/manifests/:user": => redirect_to: @url_for("user_manifest", user: @params.user)
@@ -160,4 +166,3 @@ class MoonRocksManifest extends lapis.Application
 
     @manifests = @pager\get_page @page
     render: true
-

--- a/spec/manifest_spec.moon
+++ b/spec/manifest_spec.moon
@@ -75,13 +75,11 @@ describe "moonrocks", ->
     should_load_manifest "/manifest#{v}", is_empty_manifest
     should_load_manifest "/dev/manifest#{v}", is_empty_manifest
 
+    should_load_zip_manifest "/manifest#{v}.zip"
+    should_load_zip_manifest "/dev/manifest#{v}.zip"
 
-    if v != ""
-      should_load_zip_manifest "/manifest#{v}.zip"
-      should_load_zip_manifest "/dev/manifest#{v}.zip"
-
-      should_load_json_manifest "/manifest#{v}.json"
-      should_load_json_manifest "/dev/manifest#{v}.json"
+    should_load_json_manifest "/manifest#{v}.json"
+    should_load_json_manifest "/dev/manifest#{v}.json"
 
   has_module = (manifest, mod) ->
     assert manifest.repository[mod.name],
@@ -107,6 +105,7 @@ describe "moonrocks", ->
       should_load_manifest "/manifest-5.1", (m) -> has_module m, mod
       should_load_manifest "/manifest-5.2", (m) -> has_module m, mod
 
+      should_load_zip_manifest "/manifest.zip", (m) -> has_module m, mod
       should_load_zip_manifest "/manifest-5.1.zip", (m) -> has_module m, mod
       should_load_zip_manifest "/manifest-5.2.zip", (m) -> has_module m, mod
 
@@ -153,6 +152,7 @@ describe "moonrocks", ->
       should_load_manifest "/dev/manifest-5.1", (m) -> has_module m, mod
       should_load_manifest "/dev/manifest-5.2", (m) -> has_module m, mod
 
+      should_load_zip_manifest "/dev/manifest.zip", (m) -> has_module m, mod
       should_load_zip_manifest "/dev/manifest-5.1.zip", (m) -> has_module m, mod
       should_load_zip_manifest "/dev/manifest-5.2.zip", (m) -> has_module m, mod
 


### PR DESCRIPTION
To be more specific, the following resources has been added:

* /manifest.json
* /manifest.zip
* /dev/manifest.json
* /dev/manifest.zip
* /manifests/:user/manifest.json
* /manifests/:user/manifest.zip